### PR TITLE
fix lintian

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -1,6 +1,0 @@
-conectar-bullets for Debian
----------------------------
-
-<possible notes regarding this package - if none, delete this file>
-
- -- Miguel Angel Garcia <mmiguelgarcia@anses.gov.ar>  Mon, 10 Sep 2012 16:47:21 -0300

--- a/debian/README.source
+++ b/debian/README.source
@@ -1,9 +1,0 @@
-conectar-bullets for Debian
----------------------------
-
-<this file describes information about the source package, see Debian policy
-manual section 4.14. You WILL either need to modify or delete this file>
-
-
-
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+huayra-identinet (0.5.5) UNRELEASED; urgency=low
+
+  * fix lintian:
+    + huayra-identinet is debian native, no dash is required.
+    + include ${misc:Depends} in control (fixes lintian).
+    + github url in VCS-Git field.
+    + Update Debian standards, no changes were needed.
+    + Remove Unused debian/README.*.
+    + Remove dependency on hostname, it's POSIX and shouldn't change.
+    + Change section: main (nonexisting) to admin
+
+ -- Niv Sardi <xaiki@debian.org>  Tue, 19 Feb 2013 15:08:13 -0300
+
 huayra-identinet (0.5-4) testing; urgency=low
 
   * Ajustes de pep8, pylint

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-huayra-identinet (0.5.5) UNRELEASED; urgency=low
+huayra-identinet (0.5.5+nmu0) unstable; urgency=low
 
-  * fix lintian:
+  * Non-maintainer upload: fix lintian
     + huayra-identinet is debian native, no dash is required.
     + include ${misc:Depends} in control (fixes lintian).
     + github url in VCS-Git field.

--- a/debian/control
+++ b/debian/control
@@ -1,15 +1,15 @@
 Source: huayra-identinet
-Section: main
+Section: admin
 Priority: extra
 Maintainer: Miguel Angel Garcia <miguelgarcia@anses.gov.ar>
 Build-Depends: debhelper (>= 8.0.0), python-support
-Standards-Version: 3.9.3
+Standards-Version: 3.9.4
 #Homepage: <insert the upstream URL, if relevant>
-Vcs-Git: git@200.55.245.7:/huayra-identinet.git
+Vcs-Git: http://github.com/huayralinux/huayra-identinet
 
 Package: huayra-identinet
 Architecture: all
-Depends: ${python:Depends}, python (>= 2.6), python-webkit, hostname, policykit-1
+Depends: ${misc:Depends}, ${python:Depends}, python (>= 2.6), python-webkit, policykit-1
 Conflicts: conectar-hostname-setup, huayra-hostname-setup
 Replaces: conectar-hostname-setup, huayra-hostname-setup
 Description: Configurar amigablemente el nombre de host.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,16 +1,8 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: conectar-bullets
-Source: <url://example.com>
+Upstream-Name: huayra-identinet
+Source: huayra.connectar.gob.ar
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: <special license>
- <Put the license of the package here indented by 1 space>
- <This follows the format of Description: lines in control file>
- .
- <Including paragraphs>
-
 Copyright: 2012 Miguel Angel Garcia <miguelgarcia@anses.gov.ar>
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
@@ -29,7 +21,3 @@ License: GPL-2+
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
 
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid to pick license terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.

--- a/debian/huayra-identinet-set.1
+++ b/debian/huayra-identinet-set.1
@@ -1,0 +1,39 @@
+.\" Copyright (C) 2013 Niv Sardi <xaiki@debian.org>
+.\"
+.\" This is free software; you may redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as
+.\" published by the Free Software Foundation; either version 2,
+.\" or (at your option) any later version.
+.\"
+.\" This is distributed in the hope that it will be useful, but
+.\" WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\"You should have received a copy of the GNU General Public License along
+.\"with this program; if not, write to the Free Software Foundation, Inc.,
+.\"51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.TH huayra-identinet 1 "2013\-02\-19" "Huayra"
+.SH NAME
+huayra-identinet-set \- Helper to set hostname
+.SH SYNOPSIS
+.B huayra-identinet-set new_hostname
+.RI [ OPTION... ]
+.SH DESCRIPTION
+.B huayra-identinet-set
+allows you to change the computer name (hostname) not only for the running
+session, but also goes through the work to change everything that is needed
+in /etc, and restart needed services
+.SH OPTIONS
+.TP
+.B huayra-identinet-set
+does not have any command line switches.
+.SH AUTHORS
+.B huayra-identinet-set
+was written by Author Miguel Angel Garcia <miguelgarcia@anses.gov.ar> and others
+.P
+This manual page was written by Niv Sardi <xaiki@debian.org>,
+for the Debian project (but may be used by others).
+.SH SEE ALSO
+.BR "huayra-identinet-set" (7).
+

--- a/debian/huayra-identinet.1
+++ b/debian/huayra-identinet.1
@@ -1,0 +1,41 @@
+.\" Copyright (C) 2013 Niv Sardi <xaiki@debian.org>
+.\"
+.\" This is free software; you may redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as
+.\" published by the Free Software Foundation; either version 2,
+.\" or (at your option) any later version.
+.\"
+.\" This is distributed in the hope that it will be useful, but
+.\" WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\"You should have received a copy of the GNU General Public License along
+.\"with this program; if not, write to the Free Software Foundation, Inc.,
+.\"51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.TH huayra-identinet 1 "2013\-02\-19" "Huayra"
+.SH NAME
+huayra-identinet \- Configure host name with a nice UI
+.SH SYNOPSIS
+.B huayra-identinet
+.RI [ OPTION... ]
+.SH DESCRIPTION
+.B huayra-identinet
+allows you to change the computer name (hostname) with a nice and
+comprehensive UI.
+.SH OPTIONS
+.TP
+.B huayra-identinet
+does not have any command line switches.
+.P
+.B huayra-identinet
+does not accept the standard GNOME and GTK options.
+.SH AUTHORS
+.B huayra-identinet
+was written by Author Miguel Angel Garcia <miguelgarcia@anses.gov.ar> and others
+.P
+This manual page was written by Niv Sardi <xaiki@debian.org>,
+for the Debian project (but may be used by others).
+.SH SEE ALSO
+.BR "huayra-identinet-set" (7).
+

--- a/debian/huayra-identinet.manpages
+++ b/debian/huayra-identinet.manpages
@@ -1,0 +1,2 @@
+debian/huayra-identinet.1
+debian/huayra-identinet-set.1


### PR DESCRIPTION
pasa lintian de:
W: huayra-identinet source: native-package-with-dash-version
W: huayra-identinet source: debhelper-but-no-misc-depends huayra-identinet
W: huayra-identinet source: vcs-field-uses-unknown-uri-format vcs-git git@200.55.245.7:/huayra-identinet.git
W: huayra-identinet source: changelog-should-mention-nmu
W: huayra-identinet source: source-nmu-has-incorrect-version-number 0.5-4
W: huayra-identinet source: out-of-date-standards-version 3.9.3 (current is 3.9.4)
E: huayra-identinet: helper-templates-in-copyright
W: huayra-identinet: copyright-has-url-from-dh_make-boilerplate
E: huayra-identinet: copyright-contains-dh_make-todo-boilerplate
W: huayra-identinet: readme-debian-contains-debmake-template
W: huayra-identinet: unknown-section main
E: huayra-identinet: depends-on-essential-package-without-using-version depends: hostname
W: huayra-identinet: binary-without-manpage usr/bin/huayra-identinet
W: huayra-identinet: binary-without-manpage usr/sbin/huayra-identinet-set

a: 
W: huayra-identinet: latest-debian-changelog-entry-changed-to-native
